### PR TITLE
replace tectonicClusterID tag with openshiftClusterID

### DIFF
--- a/pkg/operator/masterdns/operator.go
+++ b/pkg/operator/masterdns/operator.go
@@ -511,7 +511,7 @@ func getProviderArgs(config *installertypes.InstallConfig) []string {
 			"--provider=aws",
 			fmt.Sprintf("--domain-filter=%s", config.BaseDomain),
 			"--aws-zone-type=private",
-			fmt.Sprintf("--aws-zone-tags=tectonicClusterID=%s", config.ClusterID),
+			fmt.Sprintf("--aws-zone-tags=openshiftClusterID=%s", config.ClusterID),
 		}
 	}
 	return nil


### PR DESCRIPTION
The tectonicClusterID tag is being replaced with openshiftClusterID in the installer. This change will use the new tag name.

Hold on openshift/installer#817.

/hold